### PR TITLE
fix: use import instead of require

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 /* eslint-disable @typescript-eslint/ban-types */
-/* esline-disable no-undef */
+/* eslint-disable no-undef */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-prototype-builtins */
 
@@ -15,10 +15,10 @@ import ConvertAnsi from './plugins/ConvertAnsi';
 import DOMCollection from './plugins/DOMCollection';
 import DOMElement from './plugins/DOMElement';
 import type { Colors, Config, NewPlugin, Options, OptionsReceived, Plugin, Plugins, Refs, Theme } from './types';
+import style from 'ansi-styles';
 
 export type { Colors, Config, Options, OptionsReceived, OldPlugin, NewPlugin, Plugin, Plugins, Refs, Theme } from './types';
 
-const style = require('ansi-styles');
 
 const toString = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;

--- a/src/plugins/ConvertAnsi.ts
+++ b/src/plugins/ConvertAnsi.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const ansiRegex = require('ansi-regex');
-const style = require('ansi-styles');
+import ansiRegex from 'ansi-regex';
+import style from 'ansi-styles';
 import type { Config, NewPlugin, Printer, Refs } from '../types';
 
 const toHumanReadableAnsi = (text: string) =>


### PR DESCRIPTION
We are building a logging app, similar to the Ray app, but very specific to the Stacks ecosystem. Right now, during one of our build processes, we run into the following error:

"ReferenceError: require is not defined in ES module scope, you can use import instead"

This PR resolves this by importing the modules, instead of requiring them.

<img width="1022" alt="Screenshot 2022-12-18 at 3 09 28 PM" src="https://user-images.githubusercontent.com/6228425/208303066-a4df30ab-e9bc-4477-a863-b5f3e1378a72.png">

On a side note, I also fixed a "eslint" typo.
